### PR TITLE
Fix an editor warning in 2019.1.1f1

### DIFF
--- a/Editor/Tests/Composite/ParallelTest.cs
+++ b/Editor/Tests/Composite/ParallelTest.cs
@@ -293,7 +293,7 @@ namespace NPBehave
                 
                 sut.StopLowerPriorityChildrenForChild(firstChild, false);
             }
-            catch(Exception e)
+            catch
             {
                 bExceptionCought = true;
             }


### PR DESCRIPTION
Fix variable 'e' declared and not used.